### PR TITLE
Use pydantic models for field/table definitions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ dependencies = [
   "svcs",
   "pypika",
   "pytest-factoryboy",
+  "pytest-watcher",
 ]
 env-include = [
   "VSDATA_TEST_*",
@@ -100,6 +101,7 @@ TESTING = "1"
 
 [tool.hatch.envs.test.scripts]
 test = "pytest {args:tests}"
+watchtest = "ptw --now . {args:tests}"
 endpoints = "python -c \"from vs_data_api.main import app; print([print(route.path) for route in app.routes])\""
 
 test_int = "pytest {args:tests} --fmdb"

--- a/src/vs_data_api/vs_data/fm/__init__.py
+++ b/src/vs_data_api/vs_data/fm/__init__.py
@@ -1,4 +1,5 @@
-class FilemakerTable:
-    """Named class to represent table/field name mappings"""
+from pydantic import BaseModel
 
-    pass
+
+class FilemakerTable(BaseModel):
+    """Named class to represent table/field name mappings"""

--- a/src/vs_data_api/vs_data/fm/constants.py
+++ b/src/vs_data_api/vs_data/fm/constants.py
@@ -40,7 +40,8 @@ def get_table_class(table_ref: str):
     then the map for the link database is used rather than the stock database.
     """
     db_table_map, table_ref = parse_db_table_prefix(table_ref)
-    return getattr(db_table_map, snake_to_camel(table_ref))
+    table_class = getattr(db_table_map, snake_to_camel(table_ref))
+    return table_class
 
 
 # TODO: accept "table:field" form
@@ -49,12 +50,16 @@ def get_fm_field_name(table_ref: str, field_ref: str) -> str:
     # TODO: accept 'table:fieldname' as one argument
     # TODO: allow table name aliases eg acq (pydantic?)
     table_class = get_table_class(table_ref)
-    return getattr(table_class, field_ref)
+    # field_name = getattr(table_class, field_ref)
+    # Get the field name from the default value of the field (compatibility detail from previous implementation)
+    # TODO: this will needed to be updated to use field alias once using pydantic models for validation
+    field_name = table_class.model_fields[field_ref].default
+    return field_name
 
 
 def get_fm_table_name(table_ref: str) -> str:
     table_class = get_table_class(table_ref)
-    fm_table_name = getattr(table_class, "table_name")
+    fm_table_name = table_class.table_name
     return strip_prefix(fm_table_name)
 
 

--- a/src/vs_data_api/vs_data/fm/link_tables.py
+++ b/src/vs_data_api/vs_data/fm/link_tables.py
@@ -1,50 +1,52 @@
+from typing import ClassVar
+
 from . import FilemakerTable
 
 
 class Products(FilemakerTable):
-    table_name = "Products"
+    table_name: ClassVar = "Products"
 
-    SKU = "SKU"
-    crop = "crop"
-    link_wc_product_id = "_kf_WooCommerceID"
-    sku = "SKU"
-    name = "Name"
-    # wc_product_id = "wc_product_id"
+    SKU: str = "SKU"
+    crop: str = "crop"
+    link_wc_product_id: int = "_kf_WooCommerceID"
+    sku: str = "SKU"
+    name: str = "Name"
+    # wc_product_id: str = "wc_product_id"
 
 
 class ProductVariations(FilemakerTable):
-    table_name = "ProductVariations"
+    table_name: ClassVar = "ProductVariations"
 
-    sku = "SKU"
-    link_wc_variation_id = "_kf_WooCommerceID"
-    variation_option = "ListProductAttributeOptions_c"
-    # name = "Name"
-    # wc_product_id = "wc_product_id"
+    sku: str = "SKU"
+    link_wc_variation_id: int = "_kf_WooCommerceID"
+    variation_option: str = "ListProductAttributeOptions_c"
+    # name: str = "Name"
+    # wc_product_id: str = "wc_product_id"
 
 
 class Orders(FilemakerTable):
-    table_name = "Orders"
+    table_name: ClassVar = "Orders"
 
-    link_wc_order_id = "_kf_WooCommerceID"
-    status = "order_status"
-    selected = "selected"  # Prevously select, which is q reserved word in SQL
-    full_name = "BillingFullName_c"
+    link_wc_order_id: int = "_kf_WooCommerceID"
+    status: str = "order_status"
+    selected: str = "selected"  # Prevously select, which is q reserved word in SQL
+    full_name: str = "BillingFullName_c"
 
-    last_api_result = "LastAPIResult"
-    date_completed_gmt = "DateCompletedGMT"
-    date_completed = "DateCompleted"
+    last_api_result: str = "LastAPIResult"
+    date_completed_gmt: str = "DateCompletedGMT"
+    date_completed: str = "DateCompleted"
 
 
 class XeroBacsInvoices(FilemakerTable):
-    table_name = "xero_bacs_invoices"
+    table_name: ClassVar = "xero_bacs_invoices"
 
-    x_contact_name = "X_contact_name"
-    x_invoice_number = "X_invoice_number"
-    x_invoice_date = "X_invoice_date"
-    x_invoice_due_date = "X_invoice_due_date"
-    description = "Description"
-    quantity = "Quantity"
-    unit_cost = "Unit cost"
-    account_code = "Account code"
-    tax_rate = "Tax Rate"
-    exported = "exported"
+    x_contact_name: str = "X_contact_name"
+    x_invoice_number: int = "X_invoice_number"
+    x_invoice_date: str = "X_invoice_date"
+    x_invoice_due_date: str = "X_invoice_due_date"
+    description: str = "Description"
+    quantity: int = "Quantity"
+    unit_cost: float = "Unit cost"
+    account_code: int = "Account code"
+    tax_rate: float = "Tax Rate"
+    exported: str = "exported"

--- a/src/vs_data_api/vs_data/fm/vs_tables.py
+++ b/src/vs_data_api/vs_data/fm/vs_tables.py
@@ -1,19 +1,22 @@
+from typing import ClassVar
+
 from . import FilemakerTable
 
 
+# TODO: classes should be pydantic models
 class Acquisitions(FilemakerTable):
-    table_name = "acquisitions"
+    table_name: ClassVar = "acquisitions"
 
-    sku = "sku"
-    crop = "crop"
-    wc_product_id = "wc_product_id"
-    wc_variation_lg_id = "wc_variation_lg_id"
-    wc_variation_regular_id = "wc_variation_regular_id"
-    not_selling_in_shop = "not_selling_in_shop"
-    price = "Sale_price"
-    lg_variation_price = "Large_price"
-    packing_batch = "packing_batch"  # previously "Packing_batch"
-    large_packing_batch = "Lrg_packing_batch"
+    sku: str = "sku"
+    crop: str = "crop"
+    wc_product_id: int = "wc_product_id"
+    wc_variation_lg_id: int = "wc_variation_lg_id"
+    wc_variation_regular_id: int = "wc_variation_regular_id"
+    not_selling_in_shop: str = "not_selling_in_shop"
+    price: float = "Sale_price"
+    lg_variation_price: float = "Large_price"
+    packing_batch: int = "packing_batch"  # previously "Packing_batch"
+    large_packing_batch: str = "Lrg_packing_batch"
 
     # foreign_table_name: {pk: "local_field_name", fk: "foreign_field_name"}
     # foreign_keys = {
@@ -22,74 +25,74 @@ class Acquisitions(FilemakerTable):
 
 
 class PacketingBatches(FilemakerTable):
-    table_name = "packeting_batches"
+    table_name: ClassVar = "packeting_batches"
 
-    awaiting_upload = "awaiting_upload"
-    sku = "sku"
-    skufk = "skufk"
-    batch_number = "batch_number"
-    packets = "packets"
-    to_pack = "to_pack"
-    pack_date = "pack_date"
-    seed_lot = "seed_lot"  # previously SeedLotFK - change to number
-    left_in_batch = "left_in_batch"
+    awaiting_upload: str = "awaiting_upload"
+    sku: str = "sku"
+    skufk: str = "skufk"
+    batch_number: int = "batch_number"
+    packets: int = "packets"
+    to_pack: int = "to_pack"
+    pack_date: str = "pack_date"
+    seed_lot: int = "seed_lot"  # previously SeedLotFK - change to number
+    left_in_batch: int = "left_in_batch"
 
 
 class LargeBatches(FilemakerTable):
-    table_name = "large_batches"  # rename table occurence 'Growers_batches'
+    table_name: ClassVar = "large_batches"  # rename table occurence 'Growers_batches'
 
-    awaiting_upload = "awaiting_upload"
-    sku = "sku"  # previously SKUFK
-    sku_variation = "sku_variation"  # previously SKU_var
-    batch_number = "batch_number"
-    packets = "packets"  # previously 'packed'
-    to_pack = "to_pack"  # previously 'packets'
-    pack_date = "pack_date"
-    seed_lot = "seed_lot"  # previously SeedLotFK - change to number
-    left_in_batch = "left_in_batch"  # previously 'Left in batch'
+    awaiting_upload: str = "awaiting_upload"
+    sku: str = "sku"  # previously SKUFK
+    sku_variation: str = "sku_variation"  # previously SKU_var
+    batch_number: int = "batch_number"
+    packets: int = "packets"  # previously 'packed'
+    to_pack: int = "to_pack"  # previously 'packets'
+    pack_date: str = "pack_date"
+    seed_lot: int = "seed_lot"  # previously SeedLotFK - change to number
+    left_in_batch: int = "left_in_batch"  # previously 'Left in batch'
 
 
 class SeedLots(FilemakerTable):
-    table_name = "seed_lots"  # rename table occurence 'Growers_batches'
+    table_name: ClassVar = "seed_lots"  # rename table occurence 'Growers_batches'
 
-    lot_number = "lot_number"
-    sku = "sku"  # previously 'SKUFK'
+    lot_number: int = "lot_number"
+    sku: str = "sku"  # previously 'SKUFK'
 
 
 class Stock(FilemakerTable):
-    table_name = "stock"
+    table_name: ClassVar = "stock"
 
-    sku = "sku"
-    stock_large = "stock_large"
-    stock_regular = "stock_regular"
-    update = "update"
-    update_large = "update_large"
+    sku: str = "sku"
+    stock_large: int = "stock_large"
+    stock_regular: int = "stock_regular"
+    update: int = "update"
+    update_large: int = "update_large"
 
 
 class StockCorrections(FilemakerTable):
-    table_name = "stock_corrections"
+    table_name: ClassVar = "stock_corrections"
 
-    id = "id"
-    sku = "sku"
-    large_packet_correction = "large_packet_correction"
-    stock_change = "stock_change"
-    wc_stock_updated = "wc_stock_updated"
-    vs_stock_updated = "vs_stock_updated"
-    comment = "comment"
+    id: int = "id"
+    sku: str = "sku"
+    large_packet_correction: int = "large_packet_correction"
+    stock_change: int = "stock_change"
+    wc_stock_updated: int = "wc_stock_updated"
+    vs_stock_updated: int = "vs_stock_updated"
+    comment: str = "comment"
 
 
 class LineItems:
-    table_name = "LineItems_Orders"
+    table_name: ClassVar = "LineItems_Orders"
 
-    wc_order_id = "order_number"  # previously "Order number"
-    sku = "SKU_fk"
-    pack_size = "pack_size"  # previously "Pack_size"
-    date = "date"  # previously "Date"
-    # date_stamp = "date_stamp"  # previously "Date_stamp" (timsetamp automatically generated)
-    quantity = "quantity"  # previously "Quantity"
-    email = "email"
-    item_cost = "item_cost"  # previously "Item cost"
-    note = "note"  # previously "Note"
-    correction_id = "correction_id"  # new field (number)
-    stock_level = "stock_level"
-    transaction_type = "transaction_type"  # previously 'Transaction_Type'
+    wc_order_id: int = "order_number"  # previously "Order number"
+    sku: str = "SKU_fk"
+    pack_size: str = "pack_size"  # previously "Pack_size"
+    date: str = "date"  # previously "Date"
+    # date_stamp: str = "date_stamp"  # previously "Date_stamp" (timsetamp automatically generated)
+    quantity: int = "quantity"  # previously "Quantity"
+    email: str = "email"
+    item_cost: float = "item_cost"  # previously "Item cost"
+    note: str = "note"  # previously "Note"
+    correction_id: int = "correction_id"  # new field (number)
+    stock_level: int = "stock_level"
+    transaction_type: str = "transaction_type"  # previously 'Transaction_Type'

--- a/src/vs_data_api/vs_data/orders/status.py
+++ b/src/vs_data_api/vs_data/orders/status.py
@@ -6,7 +6,6 @@ from os.path import exists
 
 import numpy as np
 import pandas as pd
-from datascroller import scroll
 from rich import print
 
 from vs_data_api.vs_data import log

--- a/src/vs_data_api/vs_data/products/price.py
+++ b/src/vs_data_api/vs_data/products/price.py
@@ -8,7 +8,6 @@ from os.path import exists
 
 import numpy as np
 import pandas as pd
-from datascroller import scroll
 from rich import print
 
 from vs_data_api.vs_data import log

--- a/src/vs_data_api/vs_data/stock/batch_upload.py
+++ b/src/vs_data_api/vs_data/stock/batch_upload.py
@@ -21,6 +21,7 @@ WC_MAX_API_RESULT_COUNT = 100
 
 def get_batches_awaiting_upload_join_acq(connection):
     # TODO: should get sku from join on seed_lot, not packeting_batches
+    table = _t("acquisitions")
     columns = ["awaiting_upload", "batch_number", "packets", "sku", "wc_product_id"]
     awaiting = _f("packeting_batches", "awaiting_upload")
     where = f"lower({awaiting})='yes' AND b.pack_date IS NOT NULL"
@@ -28,7 +29,7 @@ def get_batches_awaiting_upload_join_acq(connection):
     sql = (
         "SELECT B.awaiting_upload,B.batch_number, B.packets, A.sku, A.wc_product_id  "
         'FROM "packeting_batches" B '
-        'LEFT JOIN "acquisitions" A ON B.sku = A.SKU '
+        f'LEFT JOIN "{table}" A ON B.sku = A.SKU '
         "WHERE " + where
     )
     log.debug(sql)

--- a/src/vs_data_api/vs_data/stock/stock_analytics.py
+++ b/src/vs_data_api/vs_data/stock/stock_analytics.py
@@ -5,7 +5,6 @@ from os.path import exists
 
 import numpy as np
 import pandas as pd
-from datascroller import scroll
 from rich import print
 
 from vs_data_api.vs_data import log


### PR DESCRIPTION
In order to reuse the table definitions later as pydantic validated records,
first step is to extend pydantic model for the existing classes, whilst ensuring
existing table and field name lookups continue to work.

For lowest cost implementation, this is done by using the default value
of the pydantic field, though would hope to make use of field aliases at a later
point.
