### PR TITLE
80 stock correction no line item flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__
 *.log
 *.img
 tmp
+/scripts
 !**/tmp/**/.gitkeep
 
 .mypy_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,10 +101,11 @@ TESTING = "1"
 
 [tool.hatch.envs.test.scripts]
 test = "pytest {args:tests}"
+test_int = "scripts/start_test_env.zsh; pytest {args:tests} --fmdb --wcapi --skipslow"
+# test_int = "pytest {args:tests} --fmdb"
+
 watchtest = "ptw --now . {args:tests}"
 endpoints = "python -c \"from vs_data_api.main import app; print([print(route.path) for route in app.routes])\""
-
-test_int = "pytest {args:tests} --fmdb"
 test-cov = "coverage run -m pytest {args:tests}"
 cov-report = [
   "- coverage combine",

--- a/src/vs_data_api/vs_data/factories/__init__.py
+++ b/src/vs_data_api/vs_data/factories/__init__.py
@@ -2,3 +2,4 @@ import datetime
 
 from vs_data_api.vs_data.factories.acquisition import create_test_acquisition
 from vs_data_api.vs_data.factories.batch import create_batch_for_upload
+from vs_data_api.vs_data.factories.stock_correction import create_stock_correction, delete_test_stock_corrections

--- a/src/vs_data_api/vs_data/factories/__init__.py
+++ b/src/vs_data_api/vs_data/factories/__init__.py
@@ -2,4 +2,8 @@ import datetime
 
 from vs_data_api.vs_data.factories.acquisition import create_test_acquisition
 from vs_data_api.vs_data.factories.batch import create_batch_for_upload
-from vs_data_api.vs_data.factories.stock_correction import create_stock_correction, delete_test_stock_corrections
+from vs_data_api.vs_data.factories.stock_correction import (
+    create_stock_correction,
+    delete_test_line_items,
+    delete_test_stock_corrections,
+)

--- a/src/vs_data_api/vs_data/factories/stock_correction.py
+++ b/src/vs_data_api/vs_data/factories/stock_correction.py
@@ -1,0 +1,37 @@
+import pypyodbc as pyodbc
+from pypika import Order, Query, Table
+
+from vs_data_api.vs_data import log
+from vs_data_api.vs_data.fm.constants import tname as _t
+from vs_data_api.vs_data.fm.vs_tables import StockCorrections
+
+stock_corrections = Table(_t("stock_corrections"))
+
+
+def create_stock_correction(vsdb_connection, values={}, test_comment="TEST CORRECTION"):
+    data = {
+        "id": 123,
+        "sku": "BeBo",
+        "large_packet_correction": None,
+        "stock_change": 12,
+        "wc_stock_updated": None,
+        "vs_stock_updated": None,
+        # "create_line_item": 1,
+        "comment": test_comment,
+    }
+    data.update(values)
+
+    q = Query.into(stock_corrections).columns(*data.keys()).insert(*data.values())
+    vsdb_connection.cursor().execute(q.get_sql()).commit()
+
+    q = Query.from_(stock_corrections).select(*data.keys()).where(
+        stock_corrections.comment == test_comment
+    ).orderby("id", order=Order.desc)
+    correction = vsdb_connection.cursor().execute(q.get_sql()).fetchone()
+    return StockCorrections(**dict(zip(data.keys(), correction)))
+
+
+def delete_test_stock_corrections(vsdb_connection, test_comment="TEST CORRECTION"):
+    q = Query.from_(stock_corrections).delete().where(stock_corrections.comment == test_comment)
+    result = vsdb_connection.cursor().execute(q.get_sql()).commit()
+    log.info(result)

--- a/src/vs_data_api/vs_data/factories/stock_correction.py
+++ b/src/vs_data_api/vs_data/factories/stock_correction.py
@@ -6,6 +6,7 @@ from vs_data_api.vs_data.fm.constants import tname as _t
 from vs_data_api.vs_data.fm.vs_tables import StockCorrections
 
 stock_corrections = Table(_t("stock_corrections"))
+line_items = Table(_t("line_items"))
 
 
 def create_stock_correction(vsdb_connection, values={}, test_comment="TEST CORRECTION"):
@@ -16,7 +17,7 @@ def create_stock_correction(vsdb_connection, values={}, test_comment="TEST CORRE
         "stock_change": 12,
         "wc_stock_updated": None,
         "vs_stock_updated": None,
-        # "create_line_item": 1,
+        "create_line_item": 1,
         "comment": test_comment,
     }
     data.update(values)
@@ -33,5 +34,11 @@ def create_stock_correction(vsdb_connection, values={}, test_comment="TEST CORRE
 
 def delete_test_stock_corrections(vsdb_connection, test_comment="TEST CORRECTION"):
     q = Query.from_(stock_corrections).delete().where(stock_corrections.comment == test_comment)
+    result = vsdb_connection.cursor().execute(q.get_sql()).commit()
+    log.info(result)
+
+
+def delete_test_line_items(vsdb_connection, test_comment="TEST CORRECTION"):
+    q = Query.from_(line_items).delete().where(line_items.note == test_comment)
     result = vsdb_connection.cursor().execute(q.get_sql()).commit()
     log.info(result)

--- a/src/vs_data_api/vs_data/fm/constants.py
+++ b/src/vs_data_api/vs_data/fm/constants.py
@@ -44,6 +44,13 @@ def get_table_class(table_ref: str):
     return table_class
 
 
+def get_fm_table_column_aliases(table_ref: str) -> dict:
+    table_class = get_table_class(table_ref)
+    fields = table_class.model_fields
+    columns = {f: fields[f].default for f in table_class.model_fields.keys()}
+    return columns
+
+
 # TODO: accept "table:field" form
 # TODO: lookup for table shortnames eg 'acq'
 def get_fm_field_name(table_ref: str, field_ref: str) -> str:

--- a/src/vs_data_api/vs_data/fm/vs_tables.py
+++ b/src/vs_data_api/vs_data/fm/vs_tables.py
@@ -74,14 +74,15 @@ class StockCorrections(FilemakerTable):
 
     id: int = "id"
     sku: str = "sku"
-    large_packet_correction: int = "large_packet_correction"
+    large_packet_correction: int | None = "large_packet_correction"
     stock_change: int = "stock_change"
-    wc_stock_updated: int = "wc_stock_updated"
-    vs_stock_updated: int = "vs_stock_updated"
+    wc_stock_updated: int | None = "wc_stock_updated"
+    vs_stock_updated: int | None = "vs_stock_updated"
+    create_line_item: int | None = "create_line_item"
     comment: str = "comment"
 
 
-class LineItems:
+class LineItems(FilemakerTable):
     table_name: ClassVar = "LineItems_Orders"
 
     wc_order_id: int = "order_number"  # previously "Order number"

--- a/tests/integration/fm/test_corrections.py
+++ b/tests/integration/fm/test_corrections.py
@@ -15,6 +15,7 @@ from tests import _add_from_file_match_params, flag_only_test_batches_for_upload
 from vs_data_api.vs_data import log, stock
 from vs_data_api.vs_data.factories import (
     create_stock_correction,
+    delete_test_line_items,
     delete_test_stock_corrections,
 )
 from vs_data_api.vs_data.fm.constants import fname as _f
@@ -24,26 +25,45 @@ TEST_CORRECTION_ID = 99999
 TEST_COMMENT = "TEST CORRECTION"
 
 
+def line_item_created(vsdb_connection, correction_id):
+    """Check if a line item has been created for a stock correction."""
+    line_items = stock.get_line_item_for_stock_correction(vsdb_connection, correction_id)
+    return line_items
+
+
+# @pytest.mark.wcapi
 # @pytest.mark.fmdb
 def test_apply_stock_corrections(wcapi, vsdb_connection):
 
     delete_test_stock_corrections(vsdb_connection, TEST_COMMENT)
-    correction = create_stock_correction(vsdb_connection)
+    delete_test_line_items(vsdb_connection, TEST_COMMENT)
+
+    correction1 = create_stock_correction(vsdb_connection)
     correction2 = create_stock_correction(vsdb_connection, {
         "id": 1234,
         "sku": "BRSE",
         "create_line_item": None,
         "comment": TEST_COMMENT,
     })
-    assert correction
+    assert correction1
 
     applied_corrections = stock.apply_corrections_to_wc_stock(vsdb_connection, wcapi)
 
     assert applied_corrections
-    assert applied_corrections[0] == correction.id
+    assert applied_corrections[0] == correction1.id
     assert applied_corrections[1] == correction2.id
-    # Will fail if test database has other corrections ready to upload
+    # Will fail if test database is not clean - ie has other corrections ready to upload
     assert applied_corrections == [123, 1234]
+
+    from vs_data_api.vs_data.stock.corrections import get_line_items_for_stock_correction
+
+    line_items = get_line_items_for_stock_correction(vsdb_connection, correction1.id)
+
+    # Only the first correction1 should have created a line item
+    assert len(line_items) == 1
+    assert line_items[0]["correction_id"] == correction1.id
+
+
 
 # @pytest.mark.wcapi
 # def test_get_products_by_id(wcapi):

--- a/tests/integration/fm/test_corrections.py
+++ b/tests/integration/fm/test_corrections.py
@@ -1,0 +1,52 @@
+"""Test cases for the __main__ module."""
+import pypyodbc as pyodbc
+import pytest
+import requests
+import responses
+import toml
+from fastapi.testclient import TestClient
+from pypika import Field, Order, Query, Schema, Table, Tables
+
+# from objexplore import explore
+from responses import _recorder, matchers
+from rich import print
+
+from tests import _add_from_file_match_params, flag_only_test_batches_for_upload
+from vs_data_api.vs_data import log, stock
+from vs_data_api.vs_data.factories import (
+    create_stock_correction,
+    delete_test_stock_corrections,
+)
+from vs_data_api.vs_data.fm.constants import fname as _f
+from vs_data_api.vs_data.stock.corrections import apply_corrections_to_wc_stock
+
+TEST_CORRECTION_ID = 99999
+TEST_COMMENT = "TEST CORRECTION"
+
+
+# @pytest.mark.fmdb
+def test_apply_stock_corrections(wcapi, vsdb_connection):
+
+    delete_test_stock_corrections(vsdb_connection, TEST_COMMENT)
+    correction = create_stock_correction(vsdb_connection)
+    correction2 = create_stock_correction(vsdb_connection, {
+        "id": 1234,
+        "sku": "BRSE",
+        "create_line_item": None,
+        "comment": TEST_COMMENT,
+    })
+    assert correction
+
+    applied_corrections = stock.apply_corrections_to_wc_stock(vsdb_connection, wcapi)
+
+    assert applied_corrections
+    assert applied_corrections[0] == correction.id
+    assert applied_corrections[1] == correction2.id
+    # Will fail if test database has other corrections ready to upload
+    assert applied_corrections == [123, 1234]
+
+# @pytest.mark.wcapi
+# def test_get_products_by_id(wcapi):
+#     product_ids = [5316, 1690, 1744, 1696, 10350]
+#     products = stock.batch_upload.get_wc_products_by_id(wcapi, product_ids)
+#     assert products


### PR DESCRIPTION
- Add integration test for applying stock corrections
- When a stock correction is applied, only add a line item if `create_line_item` field has value

Also adds a `test_int` script to the `test` HATCH_ENV to run tests against local FileMaker and WordPress