### PR TITLE
fix tidy tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ TESTING = "1"
 
 [tool.hatch.envs.test.scripts]
 test = "pytest {args:tests}"
-test_int = "scripts/start_test_env.zsh; pytest {args:tests} --fmdb --wcapi --skipslow"
+test_int = "echo 'run scripts/start_test_env.zsh to start dependencies'; pytest {args:tests} --fmdb --wcapi --skipslow"
 # test_int = "pytest {args:tests} --fmdb"
 
 watchtest = "ptw --now . {args:tests}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,7 @@ ban-relative-imports = "all"
 [tool.ruff.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
+"**/__init__.py" = ["F401"]
 
 [tool.coverage.run]
 source_pkgs = ["vs_data_api", "tests"]

--- a/src/vs_data_api/cli/__init__.py
+++ b/src/vs_data_api/cli/__init__.py
@@ -220,7 +220,7 @@ def push_variation_prices(ctx):
 @click.option("--commit", is_flag=True, help="Commit SQL query results ")
 @click.argument("sql")
 @click.pass_context
-def run_sql(ctx, sql: str, commit: bool, fetchall=False, link: bool=False):
+def run_sql(ctx, sql: str, commit: bool, fetchall=False, link: bool = False):
     """
     Run arbitrary SQL
     """
@@ -266,7 +266,6 @@ def test_fm(ctx, link: bool):
         ...
     print("No FileMaker connection")
     return
-
 
 
 @cli.command()

--- a/src/vs_data_api/cli/__init__.py
+++ b/src/vs_data_api/cli/__init__.py
@@ -217,10 +217,11 @@ def push_variation_prices(ctx):
 @cli.command()
 @click.option("--link", is_flag=True, help="Run against WC link database")
 @click.option("--fetchall", is_flag=True, help="Commit SQL query results ")
+@click.option("--csv", "csv_file", help="Filename to save SQL query results as CSV")
 @click.option("--commit", is_flag=True, help="Commit SQL query results ")
 @click.argument("sql")
 @click.pass_context
-def run_sql(ctx, sql: str, commit: bool, fetchall=False, link: bool = False):
+def run_sql(ctx, sql: str, commit: bool, csv_file: str, fetchall=False, link: bool = False):
     """
     Run arbitrary SQL
     """
@@ -231,7 +232,13 @@ def run_sql(ctx, sql: str, commit: bool, fetchall=False, link: bool = False):
         results = fmdb.cursor().execute(sql)
         # Only relevant for a select query
         if fetchall:
-            log.debug(results.fetchall())
+            rows = results.fetchall()
+            log.debug(rows)
+            if csv_file:
+                import csv
+                with open(csv_file, "w") as f:
+                    writer = csv.writer(f, quoting=csv.QUOTE_MINIMAL, escapechar="\\")
+                    writer.writerows(rows)
             return
         log.debug(results)
         if commit:

--- a/src/vs_data_api/cli/__init__.py
+++ b/src/vs_data_api/cli/__init__.py
@@ -11,7 +11,7 @@ from rich import print
 
 from vs_data_api.__about__ import __version__
 from vs_data_api.config import Settings, TestSettings
-from vs_data_api.vs_data import orders, products, stock
+from vs_data_api.vs_data import log, orders, products, stock
 from vs_data_api.vs_data.fm import db
 from vs_data_api.vs_data.wc import api
 
@@ -72,7 +72,7 @@ def get_wc_stock(ctx, sku: str, large: bool = False):
     Get WooCommerce stock value
     """
     if large:
-        print("large stock count not implemented yet")
+        log.debug("large stock count not implemented yet")
     fmdb = ctx.parent.obj["fmdb"]
     wcapi = ctx.parent.obj["wcapi"]
     acquisitions = (
@@ -84,15 +84,15 @@ def get_wc_stock(ctx, sku: str, large: bool = False):
         .fetchall()
     )
     if not acquisitions:
-        print("No acquisitions found")
+        log.debug("No acquisitions found")
         return
     product_ids = [p["wc_product_id"] for p in acquisitions]
     wc_products = stock.get_wc_products_by_id(wcapi, product_ids)
     if wc_products:
         wc_product_stock = {p["id"]: p["stock_quantity"] for p in wc_products}
-        print(wc_product_stock)
+        log.debug(wc_product_stock)
         return
-    print("No WC product found")
+    log.debug("No WC product found")
 
 
 @cli.command()
@@ -118,9 +118,9 @@ def update_stock_large_packets(ctx, force):
 
     batches = stock.get_large_batches_awaiting_upload_join_acq(fmdb)
     if not batches:
-        print("nothing to upload")
+        log.debug("nothing to upload")
         return
-    print(batches)
+    log.debug(batches)
     confirm = input("Would you like to upload the stock from these batches? (Y/n)")
     if confirm.lower() == "y" or force:
         stock.update_wc_stock_for_new_batches(fmdb, wcapi, product_variation="large")
@@ -137,14 +137,14 @@ def import_wc_product_ids(ctx):
 
     # Get the WC:product_id for each SKU from the link database
     regular_product_skus = stock.get_product_sku_map_from_linkdb(fmlinkdb)
-    print(regular_product_skus[:10])
+    log.debug(regular_product_skus[:10])
 
     # Update acquisitions with wc_product_id
     stock.update_acquisitions_wc_id(fmdb, regular_product_skus)
 
     # Get the WC:variation_id for each SKU from the link database
     variations = stock.get_product_variation_map_from_linkdb(fmlinkdb)
-    print(variations[:10])
+    log.debug(variations[:10])
 
     # Update acquisitions with WC variation ids for large and regular packets
     stock.update_acquisitions_wc_variations(fmdb, variations)
@@ -227,13 +227,13 @@ def run_sql(ctx, sql: str, commit: bool, fetchall=False, link: bool = False):
 
     fmdb = db.connection(ctx.parent.params["fmlinkdb"]) if link else ctx.parent.obj.get("fmdb")
     with fmdb:
-        print(sql)
+        log.debug(sql)
         results = fmdb.cursor().execute(sql)
         # Only relevant for a select query
         if fetchall:
-            print(results.fetchall())
+            log.debug(results.fetchall())
             return
-        print(results)
+        log.debug(results)
         if commit:
             fmdb.commit()
     return
@@ -250,21 +250,21 @@ def test_fm(ctx, link: bool):
         try:
             fmlinkdb = db.connection(ctx.parent.params["fmlinkdb"])
             if fmlinkdb:
-                print("Link database connection OK")
+                log.debug("Link database connection OK")
                 return
         except Exception:
             ...
-        print("Link database connection failed")
+        log.debug("Link database connection failed")
         return
 
     try:
         fmdb = ctx.parent.obj["fmdb"]
         if fmdb:
-            print("FileMaker connection OK")
+            log.debug("FileMaker connection OK")
             return
     except Exception:
         ...
-    print("No FileMaker connection")
+    log.debug("No FileMaker connection")
     return
 
 

--- a/src/vs_data_api/cli/__init__.py
+++ b/src/vs_data_api/cli/__init__.py
@@ -12,7 +12,7 @@ from rich import print
 from vs_data_api.__about__ import __version__
 from vs_data_api.config import Settings, TestSettings
 from vs_data_api.vs_data import orders, products, stock
-from vs_data_api.vs_data.fm import constants, db
+from vs_data_api.vs_data.fm import db
 from vs_data_api.vs_data.wc import api
 
 # Switch pydantic settings class based on environment variable

--- a/src/vs_data_api/cli/introspection.py
+++ b/src/vs_data_api/cli/introspection.py
@@ -3,4 +3,4 @@ from vs_data_api.main import app
 
 def list_endpoints():
     for route in app.routes:
-        print(route.path) # noqa
+        print(route.path)  # noqa

--- a/src/vs_data_api/config.py
+++ b/src/vs_data_api/config.py
@@ -28,6 +28,7 @@ class Settings(BaseSettings):
     def wcapi(self):
         """Property makes woocommerce available without the underscrore (aesthetic)"""
         return self._wcapi
+
     model_config = SettingsConfigDict(env_prefix="vsdata_", case_sensitive=False)
 
 

--- a/src/vs_data_api/config.py
+++ b/src/vs_data_api/config.py
@@ -1,11 +1,9 @@
-import os
 
-import pydantic
 from pydantic import Field, PrivateAttr
 from pydantic_settings import SettingsConfigDict, BaseSettings
 from woocommerce import API as wc_api
 
-from vs_data_api.vs_data import log, wc
+from vs_data_api.vs_data import wc
 
 
 class Settings(BaseSettings):

--- a/src/vs_data_api/main.py
+++ b/src/vs_data_api/main.py
@@ -1,12 +1,11 @@
 from datetime import datetime
 from functools import lru_cache
-from typing import Optional
 
 from fastapi import Depends, FastAPI
 from starlette.responses import FileResponse
 
 from vs_data_api import config
-from vs_data_api.vs_data import orders, products, stock, wc
+from vs_data_api.vs_data import orders, stock
 from vs_data_api.vs_data.fm import db
 from vs_data_api.vs_data.products import import_wc_product_ids_from_linkdb
 

--- a/src/vs_data_api/main.py
+++ b/src/vs_data_api/main.py
@@ -167,6 +167,7 @@ async def update_wc_variation_prices(settings: config.Settings = Depends(get_set
     connection = db.connection(settings.fm_connection_string)
     with connection:
         from vs_data_api.vs_data.products.price import push_variation_prices_to_wc
+
         variations, audit_log_path = push_variation_prices_to_wc(settings.wcapi, connection)
 
     if not variations:
@@ -220,8 +221,8 @@ async def import_wc_product_ids(settings: config.Settings = Depends(get_settings
 
     regular_product_skus, variations = import_wc_product_ids_from_linkdb(vsdb, linkdb)
 
-    return {"message": (
-            f"{len(regular_product_skus)} regular product skus imported.\n"
-            "{len(variations)} variation skus imported."
-            )
-        }
+    return {
+        "message": (
+            f"{len(regular_product_skus)} regular product skus imported.\n" "{len(variations)} variation skus imported."
+        )
+    }

--- a/src/vs_data_api/main.py
+++ b/src/vs_data_api/main.py
@@ -166,7 +166,8 @@ async def update_wc_variation_prices(settings: config.Settings = Depends(get_set
     """
     connection = db.connection(settings.fm_connection_string)
     with connection:
-        variations, audit_log_path = products.push_variation_prices_to_wc(settings.wcapi, connection)
+        from vs_data_api.vs_data.products.price import push_variation_prices_to_wc
+        variations, audit_log_path = push_variation_prices_to_wc(settings.wcapi, connection)
 
     if not variations:
         return {"message": "No variations were updated on WooCommerce", "variations": None}

--- a/src/vs_data_api/vs_data/__main__.py
+++ b/src/vs_data_api/vs_data/__main__.py
@@ -5,7 +5,7 @@ Command-line interface to interact with Vital Seeds database.
 import click
 from rich import print
 
-from vs_data_api.vs_data import orders, products, stock
+from vs_data_api.vs_data import log, orders, products, stock
 from vs_data_api.vs_data.fm import db
 from vs_data_api.vs_data.products import import_wc_product_ids_from_linkdb
 from vs_data_api.vs_data.wc import api
@@ -60,7 +60,7 @@ def get_wc_stock(ctx, sku: str, large: bool = False):
     Get WooCommerce stock value
     """
     if large:
-        print("large stock count not implemented yet")
+        log.debug("large stock count not implemented yet")
     fmdb = ctx.parent.obj["fmdb"]
     wcapi = ctx.parent.obj["wcapi"]
     acquisitions = (
@@ -72,15 +72,15 @@ def get_wc_stock(ctx, sku: str, large: bool = False):
         .fetchall()
     )
     if not acquisitions:
-        print("No acquisitions found")
+        log.debug("No acquisitions found")
         return
     product_ids = [p["wc_product_id"] for p in acquisitions]
     wc_products = stock.get_wc_products_by_id(wcapi, product_ids)
     if wc_products:
         wc_product_stock = {p["id"]: p["stock_quantity"] for p in wc_products}
-        print(wc_product_stock)
+        log.debug(wc_product_stock)
         return
-    print("No WC product found")
+    log.debug("No WC product found")
 
 
 @cli.command()
@@ -106,9 +106,9 @@ def update_stock_large_packets(ctx, force):
 
     batches = stock.get_large_batches_awaiting_upload_join_acq(fmdb)
     if not batches:
-        print("nothing to upload")
+        log.debug("nothing to upload")
         return
-    print(batches)
+    log.debug(batches)
     confirm = input("Would you like to upload the stock from these batches? (Y/n)")
     if confirm.lower() == "y" or force:
         stock.update_wc_stock_for_new_batches(fmdb, wcapi, product_variation="large")
@@ -201,13 +201,13 @@ def run_sql(ctx, sql: str, commit: bool, fetchall=False):
     """
     fmdb = ctx.parent.obj.get("fmdb")
     with fmdb:
-        print(sql)
+        log.debug(sql)
         results = fmdb.cursor().execute(sql)
         # Only relevant for a select query
         if fetchall:
-            print(results.fetchall())
+            log.debug(results.fetchall())
             return
-        print(results)
+        log.debug(results)
         if commit:
             fmdb.commit()
 
@@ -218,7 +218,7 @@ def test_fm(ctx):
     """
     Test FileMaker connection
     """
-    print("Testing FileMaker connection")
+    log.debug("Testing FileMaker connection")
     # fmdb = ctx.parent.obj["fmdb"]
 
 

--- a/src/vs_data_api/vs_data/__main__.py
+++ b/src/vs_data_api/vs_data/__main__.py
@@ -1,13 +1,12 @@
 """
 Command-line interface to interact with Vital Seeds database.
 """
-import os
 
 import click
 from rich import print
 
 from vs_data_api.vs_data import orders, products, stock
-from vs_data_api.vs_data.fm import constants, db
+from vs_data_api.vs_data.fm import db
 from vs_data_api.vs_data.products import import_wc_product_ids_from_linkdb
 from vs_data_api.vs_data.wc import api
 

--- a/src/vs_data_api/vs_data/__main__.py
+++ b/src/vs_data_api/vs_data/__main__.py
@@ -193,6 +193,7 @@ def push_variation_prices(ctx):
 @cli.command()
 @click.option("--fetchall", is_flag=True, help="Commit SQL query results ")
 @click.option("--commit", is_flag=True, help="Commit SQL query results ")
+@click.option("--csv", is_flag=True, help="Commit SQL query results ")
 @click.argument("sql")
 @click.pass_context
 def run_sql(ctx, sql: str, commit: bool, fetchall=False):
@@ -200,12 +201,14 @@ def run_sql(ctx, sql: str, commit: bool, fetchall=False):
     Run arbitrary SQL
     """
     fmdb = ctx.parent.obj.get("fmdb")
+
     with fmdb:
         log.debug(sql)
         results = fmdb.cursor().execute(sql)
         # Only relevant for a select query
         if fetchall:
             log.debug(results.fetchall())
+
             return
         log.debug(results)
         if commit:

--- a/src/vs_data_api/vs_data/factories/acquisition.py
+++ b/src/vs_data_api/vs_data/factories/acquisition.py
@@ -1,8 +1,6 @@
 import pypyodbc as pyodbc
-from pypika import Field, Order, Query, Schema, Table, Tables
 
 from vs_data_api.vs_data import log
-from vs_data_api.vs_data.factories.utils import param_types_from_var
 
 
 # TODO: acquisition factory

--- a/src/vs_data_api/vs_data/factories/batch.py
+++ b/src/vs_data_api/vs_data/factories/batch.py
@@ -1,6 +1,5 @@
 import datetime
 
-from pypika import Field, Order, Query, Schema, Table, Tables
 
 from vs_data_api.vs_data import log
 from vs_data_api.vs_data.factories.utils import param_types_from_var

--- a/src/vs_data_api/vs_data/factories/batch.py
+++ b/src/vs_data_api/vs_data/factories/batch.py
@@ -14,7 +14,9 @@ def create_batch_for_upload(vsdb_connection, batch_number):
     wc_product_id = 12345
     pack_date = datetime.date.today()
 
-    sql = "INSERT INTO packeting_batches (sku, batch_number, packets, awaiting_upload, pack_date) VALUES (?, ?, ?, ?, ?)"
+    sql = (
+        "INSERT INTO packeting_batches (sku, batch_number, packets, awaiting_upload, pack_date) VALUES (?, ?, ?, ?, ?)"
+    )
     values = (sku, batch_number, packets, awaiting_upload, pack_date)
 
     # sql = (

--- a/src/vs_data_api/vs_data/factories/stock_correction.py
+++ b/src/vs_data_api/vs_data/factories/stock_correction.py
@@ -25,9 +25,12 @@ def create_stock_correction(vsdb_connection, values={}, test_comment="TEST CORRE
     q = Query.into(stock_corrections).columns(*data.keys()).insert(*data.values())
     vsdb_connection.cursor().execute(q.get_sql()).commit()
 
-    q = Query.from_(stock_corrections).select(*data.keys()).where(
-        stock_corrections.comment == test_comment
-    ).orderby("id", order=Order.desc)
+    q = (
+        Query.from_(stock_corrections)
+        .select(*data.keys())
+        .where(stock_corrections.comment == test_comment)
+        .orderby("id", order=Order.desc)
+    )
     correction = vsdb_connection.cursor().execute(q.get_sql()).fetchone()
     return StockCorrections(**dict(zip(data.keys(), correction)))
 

--- a/src/vs_data_api/vs_data/factories/stock_correction.py
+++ b/src/vs_data_api/vs_data/factories/stock_correction.py
@@ -1,4 +1,3 @@
-import pypyodbc as pyodbc
 from pypika import Order, Query, Table
 
 from vs_data_api.vs_data import log

--- a/src/vs_data_api/vs_data/orders/status.py
+++ b/src/vs_data_api/vs_data/orders/status.py
@@ -31,8 +31,7 @@ def get_selected_orders(fmlinkdb):
     )
     where = (
         # Using lower() appears to be slow
-        f"{selected}='yes' "
-        f"OR {selected}='Yes' "
+        f"{selected}='yes' OR {selected}='Yes' "
     )
     # where = (
     #     f"{selected}='Yes' "

--- a/src/vs_data_api/vs_data/orders/status.py
+++ b/src/vs_data_api/vs_data/orders/status.py
@@ -1,21 +1,11 @@
-import json
-import os
-import pickle
 from datetime import datetime
-from os.path import exists
 
-import numpy as np
-import pandas as pd
-from rich import print
 
 from vs_data_api.vs_data import log
-from vs_data_api.vs_data.cli.table import display_product_table, display_table
 from vs_data_api.vs_data.fm import db
 from vs_data_api.vs_data.fm.constants import fname as _f
 from vs_data_api.vs_data.fm.constants import tname as _t
-from vs_data_api.vs_data.fm.db import convert_pyodbc_cursor_results_to_lists
-from vs_data_api.vs_data.stock.batch_upload import get_wc_large_variations_by_product
-from vs_data_api.vs_data.stock.misc import get_all_products, get_all_wc_products, wcapi_batch_post
+from vs_data_api.vs_data.stock.misc import wcapi_batch_post
 
 LAST_BATCH_UPDATE_LOG = "tmp/orders_batch_update_response.json"
 

--- a/src/vs_data_api/vs_data/products/price.py
+++ b/src/vs_data_api/vs_data/products/price.py
@@ -1,23 +1,11 @@
 import csv
-import json
 import os
 import pathlib
-import pickle
 from datetime import datetime
-from os.path import exists
-
-import numpy as np
-import pandas as pd
-from rich import print
 
 from vs_data_api.vs_data import log
-from vs_data_api.vs_data.cli.table import display_product_table, display_table
 from vs_data_api.vs_data.fm import constants
 from vs_data_api.vs_data.fm import db as fmdb
-from vs_data_api.vs_data.fm.constants import fname as _f
-from vs_data_api.vs_data.fm.constants import tname as _t
-from vs_data_api.vs_data.fm.db import convert_pyodbc_cursor_results_to_lists
-from vs_data_api.vs_data.stock.misc import get_all_products, get_all_wc_products, wcapi_aggregate_paginated_response
 
 LAST_BATCH_UPDATE_LOG = "tmp/orders_batch_update_response.json"
 

--- a/src/vs_data_api/vs_data/sqlmodtest.py
+++ b/src/vs_data_api/vs_data/sqlmodtest.py
@@ -3,8 +3,7 @@ from typing import Optional
 
 import pypyodbc
 import sqlalchemy
-from sqlalchemy.connectors.pyodbc import PyODBCConnector
-from sqlmodel import Field, Session, SQLModel, create_engine
+from sqlmodel import Field, SQLModel
 
 # class PyPyODBCConnector(PyODBCConnector):
 #     driver = "pypyodbc"

--- a/src/vs_data_api/vs_data/stock/batch_upload.py
+++ b/src/vs_data_api/vs_data/stock/batch_upload.py
@@ -305,10 +305,10 @@ def update_acquisitions_wc_id(connection, sku_id_map):
     sku_field = _f("acquisitions", "sku")
     for row in sku_id_map:
         sql = f"UPDATE {fm_table} SET {wc_id}={row[link_wc_id]} WHERE {sku_field} = '{row['sku']}'"
-        print(sql)
+        log.debug(sql)
         cursor = connection.cursor()
         cursor.execute(sql)
-        print(cursor.rowcount)
+        log.debug(cursor.rowcount)
         connection.commit()
 
 
@@ -330,18 +330,18 @@ def update_acquisitions_wc_variations(connection, variation_id_map):
         # TODO: abstract large pack sku construction
         base_sku = row["sku"].replace("-Gr", "")
         sql = f"UPDATE {fm_table} SET {large_variation_field}={row[wc_variation_id]} WHERE {parent_product_sku} = '{base_sku}'"
-        print(sql)
+        log.debug(sql)
         cursor = connection.cursor()
         cursor.execute(sql)
-        print(cursor.rowcount)
+        log.debug(cursor.rowcount)
         connection.commit()
 
     for row in regular_variations:
         # Regular pack sku should be the same as parent product
         base_sku = row["sku"]
         sql = f"UPDATE {fm_table} SET {regular_variation_field}={row[wc_variation_id]} WHERE {parent_product_sku} = '{base_sku}'"
-        print(sql)
+        log.debug(sql)
         cursor = connection.cursor()
         cursor.execute(sql)
-        print(cursor.rowcount)
+        log.debug(cursor.rowcount)
         connection.commit()

--- a/src/vs_data_api/vs_data/stock/batch_upload.py
+++ b/src/vs_data_api/vs_data/stock/batch_upload.py
@@ -4,14 +4,11 @@ Vital Seeds FM schema specific stock management
 These will be run (via shell commands) from FM scripts
 """
 
-import logging
 from collections import defaultdict
 
 from rich import print
 
 from vs_data_api.vs_data import log
-from vs_data_api.vs_data.cli.table import display_table
-from vs_data_api.vs_data.fm import constants
 from vs_data_api.vs_data.fm import db as fmdb
 from vs_data_api.vs_data.fm.constants import fname as _f
 from vs_data_api.vs_data.fm.constants import tname as _t

--- a/src/vs_data_api/vs_data/stock/cli_commands.py
+++ b/src/vs_data_api/vs_data/stock/cli_commands.py
@@ -1,5 +1,3 @@
-import click
-from rich import print
 
 # See __main__.py for now
 

--- a/src/vs_data_api/vs_data/stock/corrections.py
+++ b/src/vs_data_api/vs_data/stock/corrections.py
@@ -506,9 +506,13 @@ def get_line_items_for_stock_correction(connection, correction_id: int) -> list[
     column_aliases = get_fm_table_column_aliases("line_items").values()
     cid = _f("line_items", "correction_id")
 
-    q = Query.from_(line_items).select(*column_aliases).where(
-        # line_items.correction_id == correction_id
-        getattr(line_items, cid) == correction_id
+    q = (
+        Query.from_(line_items)
+        .select(*column_aliases)
+        .where(
+            # line_items.correction_id == correction_id
+            getattr(line_items, cid) == correction_id
+        )
     )
     line_items = connection.cursor().execute(q.get_sql()).fetchall()
 

--- a/src/vs_data_api/vs_data/stock/corrections.py
+++ b/src/vs_data_api/vs_data/stock/corrections.py
@@ -4,18 +4,15 @@ Vital Seeds FM schema specific stock management
 These will be run (via shell commands) from FM scripts
 """
 
-import logging
 import os
 from collections import defaultdict
 from datetime import datetime
 from textwrap import dedent
 
-from pypika import Order, Query, Table
-from rich import print
+from pypika import Query, Table
 
 from vs_data_api.vs_data import log
-from vs_data_api.vs_data.cli.table import display_table
-from vs_data_api.vs_data.fm import constants, db
+from vs_data_api.vs_data.fm import constants
 from vs_data_api.vs_data.fm import db as fmdb
 from vs_data_api.vs_data.fm.constants import fname as _f
 from vs_data_api.vs_data.fm.constants import get_fm_table_column_aliases

--- a/src/vs_data_api/vs_data/stock/misc.py
+++ b/src/vs_data_api/vs_data/stock/misc.py
@@ -6,7 +6,6 @@ Created during development but not yet needed.
 
 import itertools
 
-from rich import print
 
 from vs_data_api.vs_data import log
 from vs_data_api.vs_data.fm import constants

--- a/src/vs_data_api/vs_data/stock/stock_analytics.py
+++ b/src/vs_data_api/vs_data/stock/stock_analytics.py
@@ -19,13 +19,13 @@ def _debug_data(vs_stock_pd, vs_all_stock, wc_product_stock_pd, wc_variations_st
     """
     Throwaway debug function to display some pandas data in the cli.
     """
-    print(wc_product_stock_pd.columns)
-    print(vs_stock_pd.loc[vs_stock_pd["wc_product_id__vs"] == 1694])
-    print(wc_product_stock_pd.loc[wc_product_stock_pd["id__wc_prd"] == 1694][["stock_quantity__wc_prd"]])
-    print(wc_variations_stock_pd.columns)
-    print(wc_variations_stock_pd.loc[[1694]])
-    print(report.loc[report["wc_product_id__vs"] == 1694])
-    print(
+    log.debug(wc_product_stock_pd.columns)
+    log.debug(vs_stock_pd.loc[vs_stock_pd["wc_product_id__vs"] == 1694])
+    log.debug(wc_product_stock_pd.loc[wc_product_stock_pd["id__wc_prd"] == 1694][["stock_quantity__wc_prd"]])
+    log.debug(wc_variations_stock_pd.columns)
+    log.debug(wc_variations_stock_pd.loc[[1694]])
+    log.debug(report.loc[report["wc_product_id__vs"] == 1694])
+    log.debug(
         vs_all_stock[vs_all_stock["id__wc_prd"] == 1694][
             [
                 "wc_product_id__vs",

--- a/src/vs_data_api/vs_data/stock/stock_analytics.py
+++ b/src/vs_data_api/vs_data/stock/stock_analytics.py
@@ -201,6 +201,7 @@ def compare_wc_fm_stock(fmdb, wcapi, cli: bool = False, csv: bool = False, uncac
 
     report["wc_edit_url"] = report.apply(lambda row: get_wc_edit_url(row), axis=1)
     if csv:
+        os.makedirs(REPORT_CSV_DIR, exist_ok=True)
         report.to_csv(REPORT_CSV_FILE_PATH, index=False)
 
     return REPORT_CSV_FILE_PATH

--- a/src/vs_data_api/vs_data/stock/stock_analytics.py
+++ b/src/vs_data_api/vs_data/stock/stock_analytics.py
@@ -1,21 +1,18 @@
-import json
 import os
 import pickle
 from os.path import exists
 
-import numpy as np
 import pandas as pd
 from rich import print
 
 from vs_data_api.vs_data import log
-from vs_data_api.vs_data.cli.table import display_product_table, display_table
 from vs_data_api.vs_data.fm.constants import fname as _f
-from vs_data_api.vs_data.fm.constants import tname as _t
 from vs_data_api.vs_data.fm.db import convert_pyodbc_cursor_results_to_lists
 from vs_data_api.vs_data.stock.batch_upload import get_wc_large_variations_by_product
-from vs_data_api.vs_data.stock.misc import get_all_products, get_all_wc_products
+from vs_data_api.vs_data.stock.misc import get_all_wc_products
 
-REPORT_CSV_FILE_PATH = "tmp/exports/report.csv"
+REPORT_CSV_DIR = "tmp/exports"
+REPORT_CSV_FILE_PATH = f"{REPORT_CSV_DIR}/report.csv"
 
 
 def _debug_data(vs_stock_pd, vs_all_stock, wc_product_stock_pd, wc_variations_stock_pd, wc_all_stock, report):
@@ -23,12 +20,12 @@ def _debug_data(vs_stock_pd, vs_all_stock, wc_product_stock_pd, wc_variations_st
     Throwaway debug function to display some pandas data in the cli.
     """
     print(wc_product_stock_pd.columns)
-    scroll(vs_stock_pd.loc[vs_stock_pd["wc_product_id__vs"] == 1694])
-    scroll(wc_product_stock_pd.loc[wc_product_stock_pd["id__wc_prd"] == 1694][["stock_quantity__wc_prd"]])
+    print(vs_stock_pd.loc[vs_stock_pd["wc_product_id__vs"] == 1694])
+    print(wc_product_stock_pd.loc[wc_product_stock_pd["id__wc_prd"] == 1694][["stock_quantity__wc_prd"]])
     print(wc_variations_stock_pd.columns)
-    scroll(wc_variations_stock_pd.loc[[1694]])
-    scroll(report.loc[report["wc_product_id__vs"] == 1694])
-    scroll(
+    print(wc_variations_stock_pd.loc[[1694]])
+    print(report.loc[report["wc_product_id__vs"] == 1694])
+    print(
         vs_all_stock[vs_all_stock["id__wc_prd"] == 1694][
             [
                 "wc_product_id__vs",
@@ -205,8 +202,5 @@ def compare_wc_fm_stock(fmdb, wcapi, cli: bool = False, csv: bool = False, uncac
     report["wc_edit_url"] = report.apply(lambda row: get_wc_edit_url(row), axis=1)
     if csv:
         report.to_csv(REPORT_CSV_FILE_PATH, index=False)
-
-    if cli:
-        scroll(report)
 
     return REPORT_CSV_FILE_PATH

--- a/src/vs_data_api/vs_data/wc/api.py
+++ b/src/vs_data_api/vs_data/wc/api.py
@@ -1,4 +1,3 @@
-import urllib
 
 from requests.exceptions import HTTPError
 from woocommerce import API

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -31,8 +31,8 @@ def _add_from_file_match_params(
     with open(file_path, "rb") as file:
         data = _toml.load(file)
 
-    for rsp in data["responses"]:
-        rsp = rsp["response"]
+    for response in data["responses"]:
+        rsp = response["response"]
 
         request_url = urlparse(rsp["url"])
         # Remove querystring so that responses does not add query_string_matcher:
@@ -56,11 +56,11 @@ def flag_only_test_batches_for_upload(connection, batch_ids: list, table_name: s
     awaiting_upload = constants.fname("packeting_batches", "awaiting_upload")
     batch_number = constants.fname("packeting_batches", "batch_number")
     cursor = connection.cursor()
-    cursor.execute(f"UPDATE {fm_table} SET {awaiting_upload}=NULL")
+    cursor.execute(f"UPDATE {fm_table} SET {awaiting_upload}=NULL")  # noqa: S608
     connection.commit()
     sql = ""
     for batch in batch_ids:
-        sql = f"UPDATE {fm_table} SET {awaiting_upload}='Yes' WHERE {batch_number} = {batch}"
+        sql = f"UPDATE {fm_table} SET {awaiting_upload}='Yes' WHERE {batch_number} = {batch}"  # noqa: S608
         cursor = connection.cursor()
         log.info(sql)
         cursor.execute(sql)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,6 +6,8 @@ from urllib.parse import urljoin, urlparse
 
 from responses import RequestsMock
 
+from vs_data_api.vs_data import log
+
 try:
     import tomli as _toml
 except ImportError:
@@ -36,7 +38,7 @@ def _add_from_file_match_params(
         # Remove querystring so that responses does not add query_string_matcher:
         # https://github.com/getsentry/responses/blob/3b3ded7661fc3369431155baefb54975ceca5162/responses/__init__.py#L387
         request_url = urljoin(rsp["url"], request_url.path)
-        print(f"{rsp['method']}: {request_url}")
+        log.info(f"{rsp['method']}: {request_url}")
 
         responses.add(
             method=rsp["method"],
@@ -60,7 +62,7 @@ def flag_only_test_batches_for_upload(connection, batch_ids: list, table_name: s
     for batch in batch_ids:
         sql = f"UPDATE {fm_table} SET {awaiting_upload}='Yes' WHERE {batch_number} = {batch}"
         cursor = connection.cursor()
-        print(sql)
+        log.info(sql)
         cursor.execute(sql)
-        print(cursor.rowcount)
+        log.debug(cursor.rowcount)
     connection.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import os
 
 import pytest
 import responses

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,18 +29,10 @@ VSDATA_WC_URL = test_settings.vsdata_wc_url
 VSDATA_WC_KEY = test_settings.vsdata_wc_key
 VSDATA_WC_SECRET = test_settings.vsdata_wc_secret
 
-# import betamax
-
-# with betamax.Betamax.configure() as config:
-#     config.cassette_library_dir = "tests/fixtures/cassettes"
-
 
 def pytest_addoption(parser):
     parser.addoption("--fmdb", action="store_true", dest="fmdb", default=False, help="enable fmdb decorated tests")
     parser.addoption("--wcapi", action="store_true", dest="wcapi", default=False, help="enable wcapi decorated tests")
-    parser.addoption(
-        "--dbmock", action="store_true", dest="dbmock", default=False, help="enable dbmock decorated tests"
-    )
     parser.addoption("--skipslow", action="store_true", dest="skipslow", default=False, help="skip slow running tests")
 
 
@@ -50,8 +42,6 @@ def pytest_configure(config):
         mark_expression.append("not fmdb")
     if not config.option.wcapi:
         mark_expression.append("not wcapi")
-    if not config.option.dbmock:
-        mark_expression.append("not dbmock")
     if config.option.skipslow:
         mark_expression.append("not slow")
     combined_markexp = " and ".join(mark_expression)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def pytest_configure(config):
         mark_expression.append("not slow")
     combined_markexp = " and ".join(mark_expression)
     if combined_markexp:
-        print(f"-m '{combined_markexp}'")
+        print(f"-m '{combined_markexp}'") # noqa
     config.option.markexpr = combined_markexp
 
 

--- a/tests/integration/fm/test_corrections.py
+++ b/tests/integration/fm/test_corrections.py
@@ -1,25 +1,13 @@
 """Test cases for the __main__ module."""
-import pypyodbc as pyodbc
 import pytest
-import requests
-import responses
-import toml
-from fastapi.testclient import TestClient
-from pypika import Field, Order, Query, Schema, Table, Tables
 
-# from objexplore import explore
-from responses import _recorder, matchers
-from rich import print
-
-from tests import _add_from_file_match_params, flag_only_test_batches_for_upload
-from vs_data_api.vs_data import log, stock
+from vs_data_api.vs_data import stock
 from vs_data_api.vs_data.factories import (
     create_stock_correction,
     delete_test_line_items,
     delete_test_stock_corrections,
 )
-from vs_data_api.vs_data.fm.constants import fname as _f
-from vs_data_api.vs_data.stock.corrections import apply_corrections_to_wc_stock
+from vs_data_api.vs_data.stock.corrections import get_line_items_for_stock_correction
 
 TEST_CORRECTION_ID = 99999
 TEST_COMMENT = "TEST CORRECTION"

--- a/tests/integration/fm/test_corrections.py
+++ b/tests/integration/fm/test_corrections.py
@@ -19,8 +19,8 @@ def line_item_created(vsdb_connection, correction_id):
     return line_items
 
 
-# @pytest.mark.wcapi
-# @pytest.mark.fmdb
+@pytest.mark.wcapi
+@pytest.mark.fmdb
 def test_apply_stock_corrections(wcapi, vsdb_connection):
 
     delete_test_stock_corrections(vsdb_connection, TEST_COMMENT)
@@ -43,18 +43,8 @@ def test_apply_stock_corrections(wcapi, vsdb_connection):
     # Will fail if test database is not clean - ie has other corrections ready to upload
     assert applied_corrections == [123, 1234]
 
-    from vs_data_api.vs_data.stock.corrections import get_line_items_for_stock_correction
-
     line_items = get_line_items_for_stock_correction(vsdb_connection, correction1.id)
 
-    # Only the first correction1 should have created a line item
+    # Only the first correction should have created a line item
     assert len(line_items) == 1
     assert line_items[0]["correction_id"] == correction1.id
-
-
-
-# @pytest.mark.wcapi
-# def test_get_products_by_id(wcapi):
-#     product_ids = [5316, 1690, 1744, 1696, 10350]
-#     products = stock.batch_upload.get_wc_products_by_id(wcapi, product_ids)
-#     assert products

--- a/tests/integration/fm/test_corrections.py
+++ b/tests/integration/fm/test_corrections.py
@@ -22,17 +22,19 @@ def line_item_created(vsdb_connection, correction_id):
 @pytest.mark.wcapi
 @pytest.mark.fmdb
 def test_apply_stock_corrections(wcapi, vsdb_connection):
-
     delete_test_stock_corrections(vsdb_connection, TEST_COMMENT)
     delete_test_line_items(vsdb_connection, TEST_COMMENT)
 
     correction1 = create_stock_correction(vsdb_connection)
-    correction2 = create_stock_correction(vsdb_connection, {
-        "id": 1234,
-        "sku": "BRSE",
-        "create_line_item": None,
-        "comment": TEST_COMMENT,
-    })
+    correction2 = create_stock_correction(
+        vsdb_connection,
+        {
+            "id": 1234,
+            "sku": "BRSE",
+            "create_line_item": None,
+            "comment": TEST_COMMENT,
+        },
+    )
     assert correction1
 
     applied_corrections = stock.apply_corrections_to_wc_stock(vsdb_connection, wcapi)

--- a/tests/integration/fm/test_endpoints.py
+++ b/tests/integration/fm/test_endpoints.py
@@ -2,7 +2,6 @@
 
 import pytest
 from fastapi.testclient import TestClient
-from starlette.responses import FileResponse
 
 
 def test_get_product_by_id(client: TestClient):

--- a/tests/integration/fm/test_endpoints_200.py
+++ b/tests/integration/fm/test_endpoints_200.py
@@ -30,7 +30,7 @@ def test_fastapi_client(client: TestClient):
 
 @pytest.mark.fmdb
 @pytest.mark.wcapi
-@pytest.mark.timeout()
+@pytest.mark.timeout(20)
 @pytest.mark.parametrize("endpoint_path", ENDPOINTS)
 def test_all_endpoints(client, endpoint_path):
     response = client.get(endpoint_path)

--- a/tests/integration/fm/test_endpoints_200.py
+++ b/tests/integration/fm/test_endpoints_200.py
@@ -36,6 +36,7 @@ def test_all_endpoints(client, endpoint_path):
     response = client.get(endpoint_path)
     assert response.status_code == 200
 
+
 @pytest.mark.fmdb
 @pytest.mark.wcapi
 @pytest.mark.slow

--- a/tests/integration/fm/test_fm.py
+++ b/tests/integration/fm/test_fm.py
@@ -1,19 +1,8 @@
 """Test cases for the __main__ module."""
-import json
-import sqlite3
-from inspect import cleandoc as dedent
-from sqlite3 import Error
 
 import pypyodbc as pyodbc
 import pytest
-import requests
-import responses
-import toml
-from responses import _recorder, matchers
-from rich import print
 
-from vs_data_api.vs_data import log, stock
-from vs_data_api.vs_data.fm import db
 
 # @pytest.mark.fmdb
 # def test_get_batches_awaiting_upload_join_acq(vsdb_connection):

--- a/tests/integration/fm/test_stock.py
+++ b/tests/integration/fm/test_stock.py
@@ -1,20 +1,12 @@
 """Test cases for the __main__ module."""
-import pypyodbc as pyodbc
 import pytest
-import requests
-import responses
-import toml
-from fastapi.testclient import TestClient
-from pypika import Field, Order, Query, Schema, Table, Tables
+from pypika import Order, Query, Tables
 
 # from objexplore import explore
-from responses import _recorder, matchers
-from rich import print
 
-from tests import _add_from_file_match_params, flag_only_test_batches_for_upload
+from tests import flag_only_test_batches_for_upload
 from vs_data_api.vs_data import log, stock
 from vs_data_api.vs_data.factories import create_batch_for_upload, create_test_acquisition
-from vs_data_api.vs_data.fm.constants import fname as _f
 
 TEST_BATCH_ID = 99999
 

--- a/tests/integration/fm/test_stock.py
+++ b/tests/integration/fm/test_stock.py
@@ -19,7 +19,7 @@ from vs_data_api.vs_data.fm.constants import fname as _f
 TEST_BATCH_ID = 99999
 
 
-def get_test_batch(vsdb_connection, batch_number):
+def get_test_batch(vsdb_connection, batch_number=TEST_BATCH_ID):
     # awaiting = _f("packeting_batches", "awaiting_upload")
     # # where = f"lower({awaiting})='yes' AND b.pack_date IS NOT NULL"
     # where = f"lower({awaiting})='yes' AND B.batch_number = {batch_number}"
@@ -40,7 +40,7 @@ def get_test_batch(vsdb_connection, batch_number):
         Query.from_("packeting_batches")
         .select("awaiting_upload", "batch_number", "packets")
         .where(packeting_batches.awaiting_upload == "yes")
-        .where(packeting_batches.batch_number == TEST_BATCH_ID)
+        .where(packeting_batches.batch_number == batch_number)
         .orderby("batch_number", order=Order.desc)
     )
 

--- a/tests/integration/fm/test_stock.py
+++ b/tests/integration/fm/test_stock.py
@@ -3,7 +3,6 @@ import pytest
 from pypika import Order, Query, Tables
 
 # from objexplore import explore
-
 from tests import flag_only_test_batches_for_upload
 from vs_data_api.vs_data import log, stock
 from vs_data_api.vs_data.factories import create_batch_for_upload, create_test_acquisition
@@ -48,7 +47,7 @@ def delete_test_batch(vsdb_connection, batch_number):
 
 
 def delete_test_acquisition(vsdb_connection, sku):
-    sql = f"DELETE FROM \"acquisitions\" WHERE sku = '{sku}'"
+    sql = f"DELETE FROM \"acquisitions\" WHERE sku = '{sku}'"  # noqa: S608
     log.debug(sql)
     vsdb_connection.cursor().execute(sql).commit()
 

--- a/tests/integration/fm/test_stock.py
+++ b/tests/integration/fm/test_stock.py
@@ -36,11 +36,13 @@ def get_test_batch(vsdb_connection, batch_number):
     # log.debug(sql)
 
     packeting_batches, acquisitions = Tables("packeting_batches", "acquisitions")
-    sql = Query.from_("packeting_batches").select("awaiting_upload", "batch_number", "packets").where(
-        packeting_batches.awaiting_upload == "yes"
-    ).where(
-        packeting_batches.batch_number == TEST_BATCH_ID
-    ).orderby("batch_number", order=Order.desc)
+    sql = (
+        Query.from_("packeting_batches")
+        .select("awaiting_upload", "batch_number", "packets")
+        .where(packeting_batches.awaiting_upload == "yes")
+        .where(packeting_batches.batch_number == TEST_BATCH_ID)
+        .orderby("batch_number", order=Order.desc)
+    )
 
     rows = vsdb_connection.cursor().execute(sql.get_sql()).fetchall()
     log.info(rows)
@@ -61,7 +63,6 @@ def delete_test_acquisition(vsdb_connection, sku):
 
 @pytest.mark.fmdb
 def test_get_batches_awaiting_upload_join_acq(vsdb_connection):
-
     delete_test_batch(vsdb_connection, TEST_BATCH_ID)
     delete_test_acquisition(vsdb_connection, "TEST_SKU")
 
@@ -70,14 +71,14 @@ def test_get_batches_awaiting_upload_join_acq(vsdb_connection):
 
     test_batch = get_test_batch(vsdb_connection, TEST_BATCH_ID)
     assert test_batch
-    assert len(test_batch)==1
+    assert len(test_batch) == 1
     log.info(test_batch)
 
     flag_only_test_batches_for_upload(vsdb_connection, [TEST_BATCH_ID])
 
     batches = stock.batch_upload.get_batches_awaiting_upload_join_acq(vsdb_connection)
     assert batches
-    assert len(batches)==1
+    assert len(batches) == 1
 
 
 @pytest.mark.wcapi

--- a/tests/integration/fm_mock/conftest.py
+++ b/tests/integration/fm_mock/conftest.py
@@ -1,0 +1,7 @@
+"""
+Just ignore the tests in this directory for now
+"""
+
+
+def pytest_ignore_collect(path, config):
+    return True

--- a/tests/integration/fm_mock/conftest.py
+++ b/tests/integration/fm_mock/conftest.py
@@ -3,5 +3,5 @@ Just ignore the tests in this directory for now
 """
 
 
-def pytest_ignore_collect(path, config):
+def pytest_ignore_collect():
     return True

--- a/tests/integration/fm_mock/test_odbc.py
+++ b/tests/integration/fm_mock/test_odbc.py
@@ -114,9 +114,9 @@ def test_select_columns():
     assert results
 
 
-@pytest.mark.fmdb
-def test_record__generate_batch_table(vsdb_connection):
-    # TODO: mark this test 'record'
-    # Get a subset of batch records from fmdb and save them into equivalent
-    # sqlite database.
-    ...
+# @pytest.mark.fmdb
+# def test_record__generate_batch_table(vsdb_connection):
+#     # TODO: mark this test 'record'
+#     # Get a subset of batch records from fmdb and save them into equivalent
+#     # sqlite database.
+#     ...

--- a/tests/integration/fm_mock/test_odbc.py
+++ b/tests/integration/fm_mock/test_odbc.py
@@ -1,18 +1,12 @@
 """Test cases for the __main__ module."""
-import json
 import sqlite3
 from inspect import cleandoc as dedent
-from sqlite3 import Error
 
 import pypyodbc as pyodbc
 import pytest
-import requests
-import responses
-import toml
-from responses import _recorder, matchers
 from rich import print
 
-from vs_data_api.vs_data import log, stock
+from vs_data_api.vs_data import log
 from vs_data_api.vs_data.fm import db
 
 # @pytest.mark.fmdb

--- a/tests/integration/fm_mock/test_odbc.py
+++ b/tests/integration/fm_mock/test_odbc.py
@@ -93,7 +93,7 @@ def test_create_sqlite_mock(vsdb_connection):
     fmdb_mock.cursor().execute(select_acquisitions)
 
     for acquisition in fmdb_mock.cursor().execute(select_acquisitions).fetchall():
-        print(acquisition)
+        log.debug(acquisition)
 
 
 def test_select_columns():

--- a/tests/integration/fm_mock/test_odbc.py
+++ b/tests/integration/fm_mock/test_odbc.py
@@ -4,7 +4,6 @@ from inspect import cleandoc as dedent
 
 import pypyodbc as pyodbc
 import pytest
-from rich import print
 
 from vs_data_api.vs_data import log
 from vs_data_api.vs_data.fm import db

--- a/tests/unit/test_fmdb_constants.py
+++ b/tests/unit/test_fmdb_constants.py
@@ -1,5 +1,4 @@
 """Test cases for the __main__ module."""
-import pytest
 
 from vs_data_api.vs_data.fm import constants as fm_constants
 


### PR DESCRIPTION
These are all tidy up and testing improvements, done some time ago. I would like to get them merged instead of leaving them behind.

- Remove unnused custom pytest option
- Remove un-used imports
- Fix slow tests
- ruff format
- Remove unnused test and parameters
- Accept test batch_number parameter
- Clean up unnused imports using pycln
- Ruff ignore unnused imports in __init__ files
- Replace print statements with log
- Add option to generate CSV from run-sql command
